### PR TITLE
klayout: allow tests to run without X

### DIFF
--- a/klayout.sh
+++ b/klayout.sh
@@ -6,11 +6,13 @@ ST_LOGFILE=./klayout.log
 
 [ -f "$ST_LOGFILE" ] && rm -rf "$ST_LOGFILE" || true
 
+# Using -b option to run klayout allows to run it in environment without X.
+
 # klayout does not support long options
 # hence, we don't use the common 'test_help'
 echo "- klayout help" >> $ST_LOGFILE
-klayout -h >> $ST_LOGFILE
+klayout -b -h >> $ST_LOGFILE
 
 echo "- klayout version" >> $ST_LOGFILE
-klayout -v >> $ST_LOGFILE
+klayout -b -v >> $ST_LOGFILE
 


### PR DESCRIPTION
The '-b' option also works for '-h' and '-v'.